### PR TITLE
Replace the individual loaders with a simpler parameterized one

### DIFF
--- a/hwo_sci_eng/obs_config/UVI/UVI.yaml
+++ b/hwo_sci_eng/obs_config/UVI/UVI.yaml
@@ -49,7 +49,7 @@ FUV_MOS:
     N_refl_optics: [3, 'unitless'] #number of reflective optics after telescope focal plane. Includes the grating.
   shutters: MSA
   TilingFUVMOS: [[2, 1], ['unitless', 'unitless']] #Tiling of the MSAs for FUVMOS
-  detetor: MCP
+  detector: MCP
   detectorTiling: [[2, 1], ['unitless', 'unitless']] #Tiling of MCPs for FUVMOS
 NUV_MOS:
   G300M:

--- a/hwo_sci_eng/obs_config/UVI/UVI.yaml
+++ b/hwo_sci_eng/obs_config/UVI/UVI.yaml
@@ -8,7 +8,7 @@ FUV_Imager:
     reflectivities: ../reflectivities/XeLiF_refl.yaml
     shutters: MSA
     TilingFUVMOS: [[2, 1], ['unitless', 'unitless']] #Tiling of the MSAs for FUVMOS
-    detetor: MCP
+    detector: MCP
     detectorTiling: [[2, 1], ['unitless', 'unitless']] #Tiling of MCPs for FUVMOS
 FUV_MOS:
   G120M:

--- a/hwo_sci_eng/obs_config/UVI/UVI.yaml
+++ b/hwo_sci_eng/obs_config/UVI/UVI.yaml
@@ -8,7 +8,7 @@ FUV_Imager:
     reflectivities: ../reflectivities/XeLiF_refl.yaml
     shutters: MSA
     TilingFUVMOS: [[2, 1], ['unitless', 'unitless']] #Tiling of the MSAs for FUVMOS
-    detector: MCP
+    detetor: MCP
     detectorTiling: [[2, 1], ['unitless', 'unitless']] #Tiling of MCPs for FUVMOS
 FUV_MOS:
   G120M:
@@ -49,7 +49,7 @@ FUV_MOS:
     N_refl_optics: [3, 'unitless'] #number of reflective optics after telescope focal plane. Includes the grating.
   shutters: MSA
   TilingFUVMOS: [[2, 1], ['unitless', 'unitless']] #Tiling of the MSAs for FUVMOS
-  detector: MCP
+  detetor: MCP
   detectorTiling: [[2, 1], ['unitless', 'unitless']] #Tiling of MCPs for FUVMOS
 NUV_MOS:
   G300M:

--- a/hwo_sci_eng/utils/read_yaml.py
+++ b/hwo_sci_eng/utils/read_yaml.py
@@ -1,44 +1,19 @@
 import os, yaml
 
-def eac1(): 
-    
-    with open(os.getenv('SCI_ENG_DIR') + '/obs_config/Tel/EAC1.yaml', 'r') as f:
-        eac1 = yaml.load(f, Loader=yaml.SafeLoader)
+paths = {
+    "eac1": "/obs_config/Tel/EAC1.yaml",
+    "eac2": "/obs_config/Tel/EAC2_draft.yaml",
+    "eac3": "/obs_config/Tel/EAC2_draft.yaml",
+    "hri": "/obs_config/HRI/HRI.yaml",
+    "uvi": "/obs_config/UVI/UVI.yaml",
+    "ci": "/obs_config/CI/CI.yaml"
+}
+
+def read(component):
+    """
+    A generic component reader
+    """
+    with open(os.getenv('SCI_ENG_DIR') + paths[component.lower()], 'r') as f:
+        comp_yaml = yaml.load(f, Loader=yaml.SafeLoader)
    
-    return eac1 
-
-def eac2(): 
-    
-    with open(os.getenv('SCI_ENG_DIR') + '/obs_config/Tel/EAC2_draft.yaml', 'r') as f:
-        eac2 = yaml.load(f, Loader=yaml.SafeLoader)
-
-    return eac2 
-
-def eac3(): 
-    
-    with open(os.getenv('SCI_ENG_DIR') + '/obs_config/Tel/EAC3_draft.yaml', 'r') as f:
-        eac3 = yaml.load(f, Loader=yaml.SafeLoader)
-
-    return eac3 
-
-def hri(): 
-    
-    with open(os.getenv('SCI_ENG_DIR') + '/obs_config/HRI/HRI.yaml', 'r') as f:
-        hri = yaml.load(f, Loader=yaml.SafeLoader)
-   
-    return hri 
-
-def uvi(): 
-
-    with open(os.getenv('SCI_ENG_DIR') + '/obs_config/UVI/UVI.yaml', 'r') as f:
-        uvi= yaml.load(f, Loader=yaml.SafeLoader)
-
-    return uvi 
-
-def ci(): 
-
-    with open(os.getenv('SCI_ENG_DIR') + '/obs_config/CI/CI.yaml', 'r') as f:
-        ci = yaml.load(f, Loader=yaml.SafeLoader)
-
-    return ci 
-
+    return comp_yaml

--- a/hwo_sci_eng/utils/read_yaml.py
+++ b/hwo_sci_eng/utils/read_yaml.py
@@ -9,7 +9,7 @@ paths = {
     "ci": "/obs_config/CI/CI.yaml"
 }
 
-def read_eac(component):
+def read_hwo(component):
     """
     A generic component reader
     """
@@ -19,19 +19,19 @@ def read_eac(component):
     return comp_yaml
 
 def eac1():
-    return read_eac("eac1")
+    return read_hwo("eac1")
 
 def eac2():
-    return read_eac("eac2")
+    return read_hwo("eac2")
 
 def eac3():
-    return read_eac("eac3")
+    return read_hwo("eac3")
 
 def hri():
-    return read_eac("hri")
+    return read_hwo("hri")
 
 def uvi():
-    return read_eac("uvi")
+    return read_hwo("uvi")
 
 def ci():
-    return read_eac("ci")
+    return read_hwo("ci")

--- a/hwo_sci_eng/utils/read_yaml.py
+++ b/hwo_sci_eng/utils/read_yaml.py
@@ -9,7 +9,7 @@ paths = {
     "ci": "/obs_config/CI/CI.yaml"
 }
 
-def read(component):
+def read_eac(component):
     """
     A generic component reader
     """
@@ -17,3 +17,21 @@ def read(component):
         comp_yaml = yaml.load(f, Loader=yaml.SafeLoader)
    
     return comp_yaml
+
+def eac1():
+    return read_eac("eac1")
+
+def eac2():
+    return read_eac("eac2")
+
+def eac3():
+    return read_eac("eac3")
+
+def hri():
+    return read_eac("hri")
+
+def uvi():
+    return read_eac("uvi")
+
+def ci():
+    return read_eac("ci")


### PR DESCRIPTION
This simplifies the loader function. The only difference between the functions was the path to be loaded.

This is an API change that would need to propagate to syo_tools and other downstream users, but I think having them pass a string rather than open a specific function will result in simpler code everywhere.